### PR TITLE
Mergemaster

### DIFF
--- a/uc2rest/canota.py
+++ b/uc2rest/canota.py
@@ -545,6 +545,8 @@ class CANOTA(object):
         buf = bytearray()
         while time.time() < deadline:
             chunk = ser.read(ser.in_waiting or 1)
+            # debug print of chunks 
+            # self._parent.logger.debug(f"Received chunk: {chunk}")
             if chunk:
                 buf.extend(chunk)
                 obj = self._try_extract_json_status(bytes(buf))

--- a/uc2rest/canota.py
+++ b/uc2rest/canota.py
@@ -58,7 +58,11 @@ class CANOTA(object):
         """
         self._parent = parent
         self.nCallbacks = nCallbacks
-        
+
+        # Threading event: set to True to request cancellation of any running
+        # streaming upload.
+        self._cancel_event = threading.Event()
+
         # Initialize callback functions for different types of OTA events
         self.init_callback_functions(self.nCallbacks)
         
@@ -294,6 +298,15 @@ class CANOTA(object):
     # MD5) and wait for ``{"ota_status":"success"|"error"}``.
     # ========================================================================
 
+    def cancel_streaming_ota(self):
+        """Request cancellation of any running streaming upload.
+
+        The upload worker checks this flag at every chunk boundary and will
+        abort cleanly (restoring the parent serial connection) on the next
+        iteration.
+        """
+        self._cancel_event.set()
+
     def start_can_streaming_ota(self, can_id: int, firmware_path: str,
                                  progress_callback=None, status_callback=None,
                                  port: str = None, baud: int = STREAMING_BAUD):
@@ -349,6 +362,8 @@ class CANOTA(object):
                   crc32, num_chunks, progress_callback, status_callback)
         )
         upload_thread.daemon = True
+        # Reset any previous cancellation before starting the new upload
+        self._cancel_event.clear()
         upload_thread.start()
 
         return upload_thread
@@ -434,6 +449,12 @@ class CANOTA(object):
             chunk_no = 0
 
             while sent < firmware_size:
+                # Honour cancellation requests between chunks
+                if self._cancel_event.is_set():
+                    if status_callback:
+                        status_callback("Upload cancelled by user", False)
+                    return
+
                 end = min(sent + CHUNK_SIZE, firmware_size)
                 payload = firmware_data[sent:end]
                 chunk_no += 1
@@ -445,6 +466,11 @@ class CANOTA(object):
                 # Block until the master ACKs at least ``sent`` bytes.
                 deadline = time.time() + ACK_TIMEOUT_S
                 while last_ack < sent:
+                    # Check for cancellation inside the ACK wait loop as well
+                    if self._cancel_event.is_set():
+                        if status_callback:
+                            status_callback("Upload cancelled by user", False)
+                        return
                     last_ack, err = self._drain_acks(ser, ack_buf, last_ack)
                     if err is not None:
                         if status_callback:

--- a/uc2rest/home.py
+++ b/uc2rest/home.py
@@ -322,6 +322,8 @@ class Home(object):
      
         timeout = timeout if isBlocking else 0
         nResponses = 2 # one for command received, one for home reached
+        if timeout>100:
+            timeout = timeout//1000     
         
         # if we get a return, we will receive the latest position feedback from the driver  by means of the axis that moves the longest
         r = self._parent.post_json(path, payload, getReturn=isBlocking, timeout=timeout, nResponses=nResponses)

--- a/uc2rest/home.py
+++ b/uc2rest/home.py
@@ -322,8 +322,8 @@ class Home(object):
      
         timeout = timeout if isBlocking else 0
         nResponses = 2 # one for command received, one for home reached
-        if timeout>100:
-            timeout = timeout//1000     
+        if timeout and timeout > 1000:
+            timeout = timeout / 1000.0
         
         # if we get a return, we will receive the latest position feedback from the driver  by means of the axis that moves the longest
         r = self._parent.post_json(path, payload, getReturn=isBlocking, timeout=timeout, nResponses=nResponses)

--- a/uc2rest/motor.py
+++ b/uc2rest/motor.py
@@ -402,8 +402,10 @@ class Motor(object):
         return self.move_axis_by_name(axis="A", steps=steps, speed=speed, acceleration=acceleration, is_blocking=is_blocking, is_absolute=is_absolute, is_enabled=is_enabled, timeout=timeout, is_reduced=is_reduced)
 
     def move_xyz(self, steps=(0,0,0), speed=(1000,1000,1000), acceleration=None, is_blocking=False, is_absolute=False, is_enabled=True, timeout=gTIMEOUT, is_reduced=False):
-        if len(speed)!= 3:
+        if not (type(speed)==list) or len(speed)!= 3:
             speed = (speed,speed,speed)
+        if acceleration is None:
+            acceleration = (self.DEFAULT_ACCELERATION,self.DEFAULT_ACCELERATION,self.DEFAULT_ACCELERATION)
 
         # motor axis is 1,2,3,0 => X,Y,Z,T # FIXME: Hardcoded
         r = self.move_xyza(steps=(0,steps[0],steps[1],steps[2]), acceleration=(0,acceleration[0],acceleration[1],acceleration[2]), speed=(0,speed[0],speed[1],speed[2]), is_blocking=is_blocking, is_absolute=is_absolute, is_enabled=is_enabled, timeout=timeout, is_reduced=is_reduced)

--- a/uc2rest/mserial.py
+++ b/uc2rest/mserial.py
@@ -526,7 +526,7 @@ class Serial:
         iRetry = 0
         while self.running:
             time.sleep(0.002)
-            isTimeout = time.time()-t0>timeout
+            isTimeout = (time.time()-t0)>timeout
             if self.resetLastCommand or isTimeout or not self.is_connected:
                 self.resetLastCommand = False
                 if self.DEBUG: 

--- a/uc2rest/mserial.py
+++ b/uc2rest/mserial.py
@@ -490,8 +490,8 @@ class Serial:
         except Exception as e:
             if self.DEBUG: 
                 self._logger.error(e) # TODO:  write failed: Device not configured - why?!
-                # attempt to reconnect 
-                self.reconnect()
+                # attempt to reconnect # TODO: do we want that? 
+                # self.reconnect()
             return "Failed to Send"
         self.commands[identifier]=command # FIXME: Need to clear this after the response is received
         if nResponses <= 0 or not self.is_connected or self.manufacturer=="UC2Mock":


### PR DESCRIPTION
This pull request introduces a cancellation mechanism for streaming OTA uploads, improves robustness in motor movement commands, and includes minor bug fixes and code cleanups across several modules. The main focus is on allowing users to safely cancel ongoing firmware uploads, ensuring thread safety and user feedback. Additional improvements include better handling of input types and defaults in motor commands, and minor timeout and reconnect logic tweaks.

**Streaming OTA upload cancellation:**
* Added a `threading.Event` (`_cancel_event`) to the `canota.py` class to allow cancellation of streaming OTA uploads. This event is checked between chunks and during ACK waits, ensuring that uploads can be aborted cleanly and user feedback is provided when cancelled. [[1]](diffhunk://#diff-c0fe96bd222f27e4860157e5af3cdf7a4e1c91b96560de20024f8355a266b85dR62-R65) [[2]](diffhunk://#diff-c0fe96bd222f27e4860157e5af3cdf7a4e1c91b96560de20024f8355a266b85dR301-R309) [[3]](diffhunk://#diff-c0fe96bd222f27e4860157e5af3cdf7a4e1c91b96560de20024f8355a266b85dR365-R366) [[4]](diffhunk://#diff-c0fe96bd222f27e4860157e5af3cdf7a4e1c91b96560de20024f8355a266b85dR452-R457) [[5]](diffhunk://#diff-c0fe96bd222f27e4860157e5af3cdf7a4e1c91b96560de20024f8355a266b85dR469-R473)

**Motor and movement command improvements:**
* Improved type checking and default handling in `move_xyz` (in `motor.py`): now ensures `speed` is a list of length 3 and sets a default acceleration tuple if not provided.
* Adjusted `home` command timeout scaling in `home.py` to convert large timeouts to seconds for consistency.

**Serial communication and timeout handling:**
* Changed timeout comparison in `sendMessage` (in `mserial.py`) to use explicit parentheses for clarity; commented out automatic reconnect on send failure to avoid unintended side effects. [[1]](diffhunk://#diff-5d222ddbc5a073030d8ea63179e80042f5c36f0e2fec2366b24bba0e83042c5eL493-R494) [[2]](diffhunk://#diff-5d222ddbc5a073030d8ea63179e80042f5c36f0e2fec2366b24bba0e83042c5eL529-R529)

**Miscellaneous:**
* Added a commented-out debug print for received serial chunks in `_wait_for_status` for easier troubleshooting in the future.