### PR TITLE
Add set_mode to GPIO and fix checkFirmware error

### DIFF
--- a/uc2rest/gpio.py
+++ b/uc2rest/gpio.py
@@ -150,6 +150,22 @@ class GPIO(object):
 
     def calibrate(self, node=None, timeout=1):
         """Tell the slave to take its CURRENT rolling mean as the new
-        reference (persisted in NVS). Do this while the system is idle and
-        collision-free."""
+        reference (persisted in NVS). MANUAL mode only — in AUTO the baseline
+        tracks itself. Do this while the system is idle and collision-free."""
         return self._act(node=node, timeout=timeout, calibrate=1)
+
+    def set_mode(self, mode, node=None, timeout=1):
+        """Select the detection mode (persisted on the slave in NVS).
+
+        mode: "auto"  (default, recommended) — adaptive baseline + robust
+              sigma z-score. Parameter-free: tracks a slowly drifting
+              background and trips on a fast deflection. No calibration.
+        mode: "manual" — fixed reference +/- threshold. Deterministic;
+              requires the reference to be calibrated to the idle level.
+
+        Accepts "auto"/"manual" or 0/1."""
+        if isinstance(mode, str):
+            mval = 1 if mode.lower() == "manual" else 0
+        else:
+            mval = 1 if int(mode) else 0
+        return self._act(node=node, timeout=timeout, mode=mval)

--- a/uc2rest/mserial.py
+++ b/uc2rest/mserial.py
@@ -364,11 +364,14 @@ class Serial:
         for i in range(500):
             # if we just want to send but not even wait for a response
             mReadline = self._read(ser)
-            if self.DEBUG and mReadline != "" and mReadline != "\n" and mReadline != b'' and mReadline != b'\n': 
-                self._logger.debug("[checkFirmware]: "+str(mReadline))
-            if mReadline.decode('utf-8').strip() == "++" or mReadline.decode('utf-8').strip().find("++")>=0:
-                self._freeSerialBuffer(ser)
-                return True
+            try:
+                if self.DEBUG and mReadline != "" and mReadline != "\n" and mReadline != b'' and mReadline != b'\n': 
+                    self._logger.debug("[checkFirmware]: "+str(mReadline))
+                if mReadline.decode('utf-8').strip() == "++" or mReadline.decode('utf-8').strip().find("++")>=0:
+                    self._freeSerialBuffer(ser)
+                    return True
+            except Exception as e:
+                self._logger.error("Error in checkFirmware: "+str(e))
         return False
 
     def _generate_identifier(self):


### PR DESCRIPTION
Add `set_mode()` to GPIO for switching between auto/manual collision detection modes (persisted in NVS). Also wrap the firmware check loop body in a try/except to prevent crashes on decode errors.